### PR TITLE
fedora-robotics: install dnf ovl plugin to fix overlayfs issues

### DIFF
--- a/fedora-robotics/Dockerfile.f28
+++ b/fedora-robotics/Dockerfile.f28
@@ -5,12 +5,17 @@ RUN echo "deltarpm=0" >> /etc/dnf/dnf.conf && \
 	# Update and clean cache afterwards
 	dnf -y update && dnf clean all
 
-# Enable COPR for PDDL planners
+# Enable COPR for PDDL planners, dnf overlay plugin, openprs, plexil
 RUN dnf install -y 'dnf-command(copr)' && \
+	dnf -y copr enable thofmann/dnf-plugin-ovl && \
 	dnf -y copr enable thofmann/planner && \
 	dnf -y copr enable timn/openprs && \
 	dnf -y copr enable thofmann/plexil && \
 	dnf clean all
+
+# Install dnf overlay plugin to avoid rpmdb errors on overlayfs
+RUN dnf install -y dnf-plugin-ovl && dnf clean all
+
 # Install robotics related dependencies, be generous
 # Not in docker: ccache
 RUN dnf install -y \


### PR DESCRIPTION
On OverlayFS, docker builds fail with rpmdb errors such as 'PANIC: fatal
region error detected; run recovery'.
This breaks all builds on Docker Hub ([example](https://hub.docker.com/r/fawkesrobotics/fedora-robotics/builds/by86pxygahuc3shzqujptqc/)).
Install the dnf ovl plugin to avoid those errors.

A detailed explanation can be found on
https://github.com/FlorianLudwig/dnf-plugin-ovl#background.