### PR TITLE
Use fawkesrobotics base images

### DIFF
--- a/fawkes-buildenv/Dockerfile.2017-f27-kinetic
+++ b/fawkes-buildenv/Dockerfile.2017-f27-kinetic
@@ -1,4 +1,4 @@
-FROM timn/fedora-ros:f27-kinetic
+FROM fawkesrobotics/fedora-ros:f27-kinetic
 
 # ROS_DISTRO set by fedora-ros layer
 

--- a/fawkes-buildenv/Dockerfile.f27-kinetic
+++ b/fawkes-buildenv/Dockerfile.f27-kinetic
@@ -1,4 +1,4 @@
-FROM timn/fedora-ros:f27-kinetic
+FROM fawkesrobotics/fedora-ros:f27-kinetic
 
 # ROS_DISTRO set by fedora-ros layer
 

--- a/fawkes-builder/Dockerfile.fedora28-kinetic
+++ b/fawkes-builder/Dockerfile.fedora28-kinetic
@@ -1,4 +1,4 @@
-FROM timn/fedora-ros:f28-kinetic
+FROM fawkesrobotics/fedora-ros:f28-kinetic
 
 # ROS_DISTRO set by fedora-ros layer
 

--- a/fawkes-robotino/Dockerfile.2016-f27-kinetic
+++ b/fawkes-robotino/Dockerfile.2016-f27-kinetic
@@ -1,4 +1,4 @@
-FROM       timn/fawkes-buildenv:f27-kinetic
+FROM       fawkesrobotics/fawkes-buildenv:f27-kinetic
 
 # ROS_DISTRO set by fedora-ros layer
 

--- a/fawkes-robotino/Dockerfile.2017-f27-kinetic-git
+++ b/fawkes-robotino/Dockerfile.2017-f27-kinetic-git
@@ -1,4 +1,4 @@
-FROM       timn/fawkes-buildenv:2017-f27-kinetic
+FROM       fawkesrobotics/fawkes-buildenv:2017-f27-kinetic
 
 ARG  SSH_AUTH_SOCK=/ssh-agent
 ARG  GIT_HEAD=master

--- a/fedora-ros/Dockerfile.f27-kinetic
+++ b/fedora-ros/Dockerfile.f27-kinetic
@@ -1,4 +1,4 @@
-FROM timn/fedora-robotics:f27
+FROM fawkesrobotics/fedora-robotics:f27
 
 ENV ROS_DISTRO=kinetic \
     SHELL=/bin/bash \

--- a/fedora-ros/Dockerfile.f28-kinetic
+++ b/fedora-ros/Dockerfile.f28-kinetic
@@ -1,4 +1,4 @@
-FROM timn/fedora-robotics:f28
+FROM fawkesrobotics/fedora-robotics:f28
 
 ENV ROS_DISTRO=kinetic \
     SHELL=/bin/bash \


### PR DESCRIPTION
To set up an automatic build chain within the organization, we need to use base images from the organization.

The images do not exist yet, but I will build them as soon this is merged.