### PR TITLE
docker-robotics: upgrade to mongocxx-v3 in Fedora 29

### DIFF
--- a/fedora-robotics/Dockerfile.f29
+++ b/fedora-robotics/Dockerfile.f29
@@ -11,6 +11,7 @@ RUN echo "deltarpm=0" >> /etc/dnf/dnf.conf && \
 # Enable COPR for PDDL planners, openprs, plexil
 RUN dnf install -y --nodocs 'dnf-command(copr)' && \
 	dnf -y copr enable thofmann/planner && \
+	dnf -y copr enable thofmann/mongocxx-v3 && \
 	dnf -y copr enable timn/openprs && \
 	dnf -y copr enable timn/clingo && \
 	dnf -y copr enable thofmann/plexil && \


### PR DESCRIPTION
Use the COPR for mongocxx-v3 to have the latest mongo-cxx-driver. Fedora
29 still ships version 1 by default.

Builds of branches that do not contain the necessary modifications for mongocxx-v3 will not fail, but the respective plugins will not be built anymore.