### PR TITLE
fedora-robotics: install libalvar from COPR

### DIFF
--- a/fedora-robotics/Dockerfile.f29
+++ b/fedora-robotics/Dockerfile.f29
@@ -10,6 +10,7 @@ RUN echo "deltarpm=0" >> /etc/dnf/dnf.conf && \
 
 # Enable COPR for PDDL planners, openprs, plexil
 RUN dnf install -y --nodocs 'dnf-command(copr)' && \
+	dnf -y copr enable thofmann/libalvar && \
 	dnf -y copr enable thofmann/planner && \
 	dnf -y copr enable thofmann/mongocxx-v3 && \
 	dnf -y copr enable timn/openprs && \
@@ -34,7 +35,7 @@ RUN dnf install -y --nodocs \
 	openssl-devel libmodbus-devel \
 	libjpeg-devel libpng-devel opencv-devel \
   orocos-kdl-devel orocos-bfl-devel \
-	libusb-devel hokuyoaist-devel libdc1394-devel libkni3-devel \
+	libalvar-devel libusb-devel hokuyoaist-devel libdc1394-devel libkni3-devel \
   librealsense1-devel \
 	libudev-devel urg-devel libkindrv-devel \
 	festival festival-devel flite-devel \


### PR DESCRIPTION
This fixes carologistics/fawkes-robotino#67.